### PR TITLE
add basic end-to-end tester service

### DIFF
--- a/docker-compose-tester.yml
+++ b/docker-compose-tester.yml
@@ -1,0 +1,28 @@
+version: "2"
+
+services:
+  rabbitmq:
+    image: rabbitmq:3.6.9-management
+    ports:
+      - 15672:5672
+  ruby-invoices:
+    build: ./ruby-invoices
+    environment:
+      - RABBIT_HOST=rabbitmq
+    depends_on:
+      - rabbitmq
+  ruby-http-proxy:
+    build: ./ruby-http-proxy
+    ports:
+      - 9292:9292
+    environment:
+      - RABBIT_HOST=rabbitmq
+    depends_on:
+      - rabbitmq
+  end-to-end-tester:
+    build: ./end-to-end-tester
+    depends_on:
+      - rabbitmq
+      - ruby-http-proxy
+      - ruby-invoices
+

--- a/end-to-end-tester/Dockerfile
+++ b/end-to-end-tester/Dockerfile
@@ -1,0 +1,22 @@
+FROM ruby:2.3.3-slim
+
+ARG BUILD_PACKAGES="git-core openssh-client g++ make libssl-dev"
+
+ENV LANG=C.UTF-8
+
+# create deploy user first to prevent packages from hijacking our canonical uid
+RUN adduser --disabled-password --system --uid 1000 deploy
+
+# install build deps
+RUN apt-get update && \
+    apt-get dist-upgrade -q -y && \
+    apt-get install -q -y --no-install-recommends $BUILD_PACKAGES
+
+RUN chown -Rh deploy /home/deploy
+WORKDIR /home/deploy/app
+
+COPY Gemfile /home/deploy/app
+RUN bundle --path=~/bundle
+
+# copy actual app sources
+ADD . /home/deploy/app

--- a/end-to-end-tester/Gemfile
+++ b/end-to-end-tester/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'rspec'
+gem 'pry'

--- a/end-to-end-tester/Gemfile.lock
+++ b/end-to-end-tester/Gemfile.lock
@@ -1,0 +1,32 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    coderay (1.1.2)
+    diff-lcs (1.3)
+    method_source (0.9.0)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.0)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  pry
+  rspec
+
+BUNDLED WITH
+   1.15.4

--- a/end-to-end-tester/spec/requests/ping_spec.rb
+++ b/end-to-end-tester/spec/requests/ping_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe 'GET /ping' do
+  subject { fail NotImplementedError }
+
+  describe 'a simple health-check endpoint' do
+    it 'returns success message' do
+      expect(subject).to eq '/ping'
+    end
+  end
+end

--- a/end-to-end-tester/spec/spec_helper.rb
+++ b/end-to-end-tester/spec/spec_helper.rb
@@ -1,0 +1,5 @@
+require 'bundler'
+Bundler.require
+
+RSpec.configure do |config|
+end


### PR DESCRIPTION
This PR introduces end-to-end tester allowing to write integration specs